### PR TITLE
Fixing odd random behaviour

### DIFF
--- a/lua/autorun/server/sv_deathgrip_handler.lua
+++ b/lua/autorun/server/sv_deathgrip_handler.lua
@@ -38,6 +38,7 @@ end
 
 local function SelectDeathgripPlayers()
 	if not TTT2 or not GetConVar("ttt2_deathgrip"):GetBool() then return end
+	math.randomseed(os.time())
 	if math.random(0, 1) > GetConVar("ttt2_deathgrip_chance"):GetFloat() then return end
 
 	local players = util.GetFilteredPlayers(function (ply)


### PR DESCRIPTION
Setting a new random seed for the pseudo-random generator to fix the problem of getting the same random numbers every iteration which results in odd behaviour if you change the convar ttt2_deathgrip_chance below the default 0.5. Before this change the deathgrip would still occur every second round even if you did set the ConVar to 0.1.